### PR TITLE
Python 3 `print()` bugfix

### DIFF
--- a/auto_cal_v2.py
+++ b/auto_cal_v2.py
@@ -218,7 +218,7 @@ def main():
         port.write(('M92 X{0} Y{0} Z{0}\n'.format(str(step_mm))).encode())
         out = port.readline().decode()
 
-        print ('Setting up M665 L{0}\n').format(str(l_value))
+        print ('Setting up M665 L{0}\n'.format(str(l_value)))
         port.write(('M665 L{0}\n'.format(str(l_value))).encode())
         out = port.readline().decode()
 


### PR DESCRIPTION
Also adds `\n` to the end of the doc.